### PR TITLE
`zero` instead of `simzeros`

### DIFF
--- a/src/synapse/spiking_synapse.jl
+++ b/src/synapse/spiking_synapse.jl
@@ -14,10 +14,10 @@ end
     J::Vector{SNNInt}      # presynaptic index of W
     index::Vector{SNNInt}  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
     W::Vector{SNNFloat}  # synaptic weight
-    tpre::Vector{SNNFloat} = simzeros(W) # presynaptic spiking time
-    tpost::Vector{SNNFloat} = simzeros(W) # postsynaptic spiking time
-    Apre::Vector{SNNFloat} = simzeros(W) # presynaptic trace
-    Apost::Vector{SNNFloat} = simzeros(W) # postsynaptic trace
+    tpre::Vector{SNNFloat} = zero(W) # presynaptic spiking time
+    tpost::Vector{SNNFloat} = zero(W) # postsynaptic spiking time
+    Apre::Vector{SNNFloat} = zero(W) # presynaptic trace
+    Apost::Vector{SNNFloat} = zero(W) # postsynaptic trace
     fireI::Vector{Bool} # postsynaptic firing
     fireJ::Vector{Bool} # presynaptic firing
     g::Vector{SNNFloat} # postsynaptic conductance

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,10 +1,8 @@
-simzeros(W) = fill!(similar(W), 0)
-
 function connect!(c, j, i, σ = 1e-6)
     W = sparse(c.I, c.J, c.W, length(c.rowptr) - 1, length(c.colptr) - 1)
     W[i, j] = σ * randn(SNNFloat)
     c.rowptr, c.colptr, c.I, c.J, c.index, c.W = dsparse(W)
-    c.tpre, c.tpost, c.Apre, c.Apost = simzeros(c.W), simzeros(c.W), simzeros(c.W), simzeros(c.W)
+    c.tpre, c.tpost, c.Apre, c.Apost = zero(c.W), zero(c.W), zero(c.W), zero(c.W)
     return nothing
 end
 
@@ -14,7 +12,7 @@ function dsparse(A)
     rowptr = At.colptr
     I = rowvals(A)
     V = nonzeros(A)
-    J = simzeros(I)
+    J = zero(I)
     # FIXME: Breaks when A is empty
     for j in 1:(length(colptr) - 1)
         J[colptr[j]:(colptr[j+1] - 1)] .= j


### PR DESCRIPTION
The built-in [`zero()`](https://docs.julialang.org/en/v1/base/numbers/#Base.zero) provides the same functionality to [`simzeros()`](https://github.com/AStupidBear/SpikingNeuralNetworks.jl/blob/a443900230668b7ce5ac7743d19477bc2cd64e07/src/utils.jl#L1).

It's different from [`zeros()`](https://docs.julialang.org/en/v1/base/arrays/#Base.zeros), which requires dimensions as parameters. [`zero()`](https://docs.julialang.org/en/v1/base/numbers/#Base.zero) takes an array/number/whatever and makes a similar one filled with 0s.



