### PR TITLE
Initial DiffEq preparations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "9d8b7fda-1049-58bc-9481-071a9f369938"
 version = "0.1.0"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -3,17 +3,17 @@ uuid = "9d8b7fda-1049-58bc-9481-071a9f369938"
 version = "0.1.0"
 
 [deps]
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Parameters = "0.12"
 Reexport = "0.2"
 Requires = "0.5, 1"
 Unitful = "0.17, 0.18, 1"
+UnPack = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 Reexport = "0.2"
 Requires = "0.5, 1"
-Unitful = "0.17, 0.18, 1"
 UnPack = "1"
+Unitful = "0.17, 0.18, 1"
 julia = "1"
 
 [extras]

--- a/src/SpikingNeuralNetworks.jl
+++ b/src/SpikingNeuralNetworks.jl
@@ -3,6 +3,7 @@ module SpikingNeuralNetworks
 export SNN
 const SNN = SpikingNeuralNetworks
 
+using LinearAlgebra
 using SparseArrays
 using Reexport
 using Requires

--- a/src/SpikingNeuralNetworks.jl
+++ b/src/SpikingNeuralNetworks.jl
@@ -1,5 +1,6 @@
 module SpikingNeuralNetworks
 
+export SNN
 const SNN = SpikingNeuralNetworks
 
 using SparseArrays

--- a/src/SpikingNeuralNetworks.jl
+++ b/src/SpikingNeuralNetworks.jl
@@ -4,15 +4,11 @@ const SNN = SpikingNeuralNetworks
 
 using SparseArrays
 using Reexport
-using Parameters
 using Requires
+using UnPack
 #using Unitful
 #using Unitful.DefaultSymbols
 #@reexport using Utils
-
-const SNNInt = Int32
-const SNNFloat = Float32
-# srand(1000)
 
 include("units.jl")
 include("main.jl")

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,6 +1,6 @@
 function sim!(P, C, dt)
     for p in P
-        integrate!(p, p.param, SNNFloat(dt))
+        integrate!(p, p.param, Float32(dt))
         record!(p)
     end
     for c in C
@@ -17,18 +17,18 @@ end
 
 function train!(P, C, dt, t = 0)
     for p in P
-        integrate!(p, p.param, SNNFloat(dt))
+        integrate!(p, p.param, Float32(dt))
         record!(p)
     end
     for c in C
         forward!(c, c.param)
-        plasticity!(c, c.param, SNNFloat(dt), SNNFloat(t))
+        plasticity!(c, c.param, Float32(dt), Float32(t))
         record!(c)
     end
 end
 
 function train!(P, C; dt = 0.1ms, duration = 10ms)
     for t = 0ms:dt:duration
-        train!(P, C, SNNFloat(dt), SNNFloat(t))
+        train!(P, C, Float32(dt), Float32(t))
     end
 end

--- a/src/neuron/hh.jl
+++ b/src/neuron/hh.jl
@@ -1,33 +1,33 @@
-@with_kw struct HHParameter
-    Cm::SNNFloat = 1uF * cm^(-2) * 20000um^2
-    gl::SNNFloat = 5e-5siemens * cm^(-2) * 20000um^2
-    El::SNNFloat = -65mV
-    Ek::SNNFloat = -90mV
-    En::SNNFloat = 50mV
-    gn::SNNFloat = 100msiemens * cm^(-2) * 20000um^2
-    gk::SNNFloat = 30msiemens * cm^(-2) * 20000um^2
-    Vt::SNNFloat = -63mV
-    τe::SNNFloat = 5ms
-    τi::SNNFloat = 10ms
-    Ee::SNNFloat = 0mV
-    Ei::SNNFloat = -80mV
+@snn_kw struct HHParameter
+    Cm::Float32 = 1uF * cm^(-2) * 20000um^2
+    gl::Float32 = 5e-5siemens * cm^(-2) * 20000um^2
+    El::Float32 = -65mV
+    Ek::Float32 = -90mV
+    En::Float32 = 50mV
+    gn::Float32 = 100msiemens * cm^(-2) * 20000um^2
+    gk::Float32 = 30msiemens * cm^(-2) * 20000um^2
+    Vt::Float32 = -63mV
+    τe::Float32 = 5ms
+    τi::Float32 = 10ms
+    Ee::Float32 = 0mV
+    Ei::Float32 = -80mV
 end
 
-@with_kw mutable struct HH
+@snn_kw mutable struct HH
     param::HHParameter = HHParameter()
-    N::SNNInt = 100
-    v::Vector{SNNFloat} = param.El .+ 5(randn(N) .- 1)
-    m::Vector{SNNFloat} = zeros(N)
-    n::Vector{SNNFloat} = zeros(N)
-    h::Vector{SNNFloat} = ones(N)
-    ge::Vector{SNNFloat}  = (1.5randn(N) .+ 4) .* 10nS
-    gi::Vector{SNNFloat}  = (12randn(N) .+ 20) .* 10nS
+    N::Int32 = 100
+    v::Vector{Float32} = param.El .+ 5(randn(N) .- 1)
+    m::Vector{Float32} = zeros(N)
+    n::Vector{Float32} = zeros(N)
+    h::Vector{Float32} = ones(N)
+    ge::Vector{Float32}  = (1.5randn(N) .+ 4) .* 10nS
+    gi::Vector{Float32}  = (12randn(N) .+ 20) .* 10nS
     fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{SNNFloat} = zeros(N)
+    I::Vector{Float32} = zeros(N)
     records::Dict = Dict()
 end
 
-function integrate!(p::HH, param::HHParameter, dt::SNNFloat)
+function integrate!(p::HH, param::HHParameter, dt::Float32)
     @unpack N, v, m, n, h, ge, gi, fire, I = p
     @unpack Cm, gl, El, Ek, En, gn, gk, Vt, τe, τi, Ee, Ei = param
     @inbounds for i = 1:N

--- a/src/neuron/hh.jl
+++ b/src/neuron/hh.jl
@@ -1,29 +1,29 @@
-@snn_kw struct HHParameter
-    Cm::Float32 = 1uF * cm^(-2) * 20000um^2
-    gl::Float32 = 5e-5siemens * cm^(-2) * 20000um^2
-    El::Float32 = -65mV
-    Ek::Float32 = -90mV
-    En::Float32 = 50mV
-    gn::Float32 = 100msiemens * cm^(-2) * 20000um^2
-    gk::Float32 = 30msiemens * cm^(-2) * 20000um^2
-    Vt::Float32 = -63mV
-    τe::Float32 = 5ms
-    τi::Float32 = 10ms
-    Ee::Float32 = 0mV
-    Ei::Float32 = -80mV
+@snn_kw struct HHParameter{FT=Float32}
+    Cm::FT = 1uF * cm^(-2) * 20000um^2
+    gl::FT = 5e-5siemens * cm^(-2) * 20000um^2
+    El::FT = -65mV
+    Ek::FT = -90mV
+    En::FT = 50mV
+    gn::FT = 100msiemens * cm^(-2) * 20000um^2
+    gk::FT = 30msiemens * cm^(-2) * 20000um^2
+    Vt::FT = -63mV
+    τe::FT = 5ms
+    τi::FT = 10ms
+    Ee::FT = 0mV
+    Ei::FT = -80mV
 end
 
-@snn_kw mutable struct HH
+@snn_kw mutable struct HH{FT=Vector{Float32},BT=Vector{Bool}}
     param::HHParameter = HHParameter()
     N::Int32 = 100
-    v::Vector{Float32} = param.El .+ 5(randn(N) .- 1)
-    m::Vector{Float32} = zeros(N)
-    n::Vector{Float32} = zeros(N)
-    h::Vector{Float32} = ones(N)
-    ge::Vector{Float32}  = (1.5randn(N) .+ 4) .* 10nS
-    gi::Vector{Float32}  = (12randn(N) .+ 20) .* 10nS
-    fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{Float32} = zeros(N)
+    v::FT = param.El .+ 5(randn(N) .- 1)
+    m::FT = zeros(N)
+    n::FT = zeros(N)
+    h::FT = ones(N)
+    ge::FT  = (1.5randn(N) .+ 4) .* 10nS
+    gi::FT  = (12randn(N) .+ 20) .* 10nS
+    fire::BT = zeros(Bool, N)
+    I::FT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/hh.jl
+++ b/src/neuron/hh.jl
@@ -13,17 +13,17 @@
     Ei::FT = -80mV
 end
 
-@snn_kw mutable struct HH{FT=Vector{Float32},BT=Vector{Bool}}
+@snn_kw mutable struct HH{VFT=Vector{Float32},VBT=Vector{Bool}}
     param::HHParameter = HHParameter()
     N::Int32 = 100
-    v::FT = param.El .+ 5(randn(N) .- 1)
-    m::FT = zeros(N)
-    n::FT = zeros(N)
-    h::FT = ones(N)
-    ge::FT  = (1.5randn(N) .+ 4) .* 10nS
-    gi::FT  = (12randn(N) .+ 20) .* 10nS
-    fire::BT = zeros(Bool, N)
-    I::FT = zeros(N)
+    v::VFT = param.El .+ 5(randn(N) .- 1)
+    m::VFT = zeros(N)
+    n::VFT = zeros(N)
+    h::VFT = ones(N)
+    ge::VFT  = (1.5randn(N) .+ 4) .* 10nS
+    gi::VFT  = (12randn(N) .+ 20) .* 10nS
+    fire::VBT = zeros(Bool, N)
+    I::VFT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/if.jl
+++ b/src/neuron/if.jl
@@ -1,26 +1,26 @@
 abstract type AbstractIFParameter end
-@with_kw struct IFParameter <: AbstractIFParameter
-    τm::SNNFloat = 20ms
-    τe::SNNFloat = 5ms
-    τi::SNNFloat = 10ms
-    Vt::SNNFloat = -50mV
-    Vr::SNNFloat = -60mV
-    El::SNNFloat = Vr
+@snn_kw struct IFParameter <: AbstractIFParameter
+    τm::Float32 = 20ms
+    τe::Float32 = 5ms
+    τi::Float32 = 10ms
+    Vt::Float32 = -50mV
+    Vr::Float32 = -60mV
+    El::Float32 = Vr
 end
 
 abstract type AbstractIF end
-@with_kw mutable struct IF <: AbstractIF
+@snn_kw mutable struct IF <: AbstractIF
     param::IFParameter = IFParameter()
-    N::SNNInt = 100
-    v::Vector{SNNFloat} = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
-    ge::Vector{SNNFloat} = zeros(N)
-    gi::Vector{SNNFloat} = zeros(N)
+    N::Int32 = 100
+    v::Vector{Float32} = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
+    ge::Vector{Float32} = zeros(N)
+    gi::Vector{Float32} = zeros(N)
     fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{SNNFloat} = zeros(N)
+    I::Vector{Float32} = zeros(N)
     records::Dict = Dict()
 end
 
-function integrate!(p::IF, param::IFParameter, dt::SNNFloat)
+function integrate!(p::IF, param::IFParameter, dt::Float32)
     @unpack N, v, ge, gi, fire, I = p
     @unpack τm, τe, τi, Vt, Vr, El = param
     @inbounds for i = 1:N

--- a/src/neuron/if.jl
+++ b/src/neuron/if.jl
@@ -9,14 +9,14 @@ abstract type AbstractIFParameter end
 end
 
 abstract type AbstractIF end
-@snn_kw mutable struct IF{FT=Vector{Float32},BT=Vector{Bool}} <: AbstractIF
+@snn_kw mutable struct IF{VFT=Vector{Float32},VBT=Vector{Bool}} <: AbstractIF
     param::IFParameter = IFParameter()
     N::Int32 = 100
-    v::FT = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
-    ge::FT = zeros(N)
-    gi::FT = zeros(N)
-    fire::BT = zeros(Bool, N)
-    I::FT = zeros(N)
+    v::VFT = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
+    ge::VFT = zeros(N)
+    gi::VFT = zeros(N)
+    fire::VBT = zeros(Bool, N)
+    I::VFT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/if.jl
+++ b/src/neuron/if.jl
@@ -1,22 +1,22 @@
 abstract type AbstractIFParameter end
-@snn_kw struct IFParameter <: AbstractIFParameter
-    τm::Float32 = 20ms
-    τe::Float32 = 5ms
-    τi::Float32 = 10ms
-    Vt::Float32 = -50mV
-    Vr::Float32 = -60mV
-    El::Float32 = Vr
+@snn_kw struct IFParameter{FT=Float32} <: AbstractIFParameter
+    τm::FT = 20ms
+    τe::FT = 5ms
+    τi::FT = 10ms
+    Vt::FT = -50mV
+    Vr::FT = -60mV
+    El::FT = Vr
 end
 
 abstract type AbstractIF end
-@snn_kw mutable struct IF <: AbstractIF
+@snn_kw mutable struct IF{FT=Vector{Float32},BT=Vector{Bool}} <: AbstractIF
     param::IFParameter = IFParameter()
     N::Int32 = 100
-    v::Vector{Float32} = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
-    ge::Vector{Float32} = zeros(N)
-    gi::Vector{Float32} = zeros(N)
-    fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{Float32} = zeros(N)
+    v::FT = param.Vr .+ rand(N) .* (param.Vt - param.Vr)
+    ge::FT = zeros(N)
+    gi::FT = zeros(N)
+    fire::BT = zeros(Bool, N)
+    I::FT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/if2.jl
+++ b/src/neuron/if2.jl
@@ -1,6 +1,6 @@
-@snn_kw struct IF2Parameter <: AbstractIFParameter
-    Ee::Float32 = 0mV
-    Ei::Float32 = 0mV
+@snn_kw struct IF2Parameter{FT=Float32} <: AbstractIFParameter
+    Ee::FT = 0mV
+    Ei::FT = 0mV
 end
 
 @snn_kw mutable struct IF2 <: AbstractIF

--- a/src/neuron/if2.jl
+++ b/src/neuron/if2.jl
@@ -1,14 +1,14 @@
-@with_kw struct IF2Parameter <: AbstractIFParameter
-    Ee::SNNFloat = 0mV
-    Ei::SNNFloat = 0mV
+@snn_kw struct IF2Parameter <: AbstractIFParameter
+    Ee::Float32 = 0mV
+    Ei::Float32 = 0mV
 end
 
-@with_kw mutable struct IF2 <: AbstractIF
+@snn_kw mutable struct IF2 <: AbstractIF
     param::IF2Parameter = IF2Parameter()
-    N::SNNInt = 100
+    N::Int32 = 100
 end
 
-function integrate!(p::IF2, param::IF2Parameter, dt::SNNFloat)
+function integrate!(p::IF2, param::IF2Parameter, dt::Float32)
     @unpack N = p
     @unpack Ee, Ei = param
     @inbounds for i = 1:N

--- a/src/neuron/iz.jl
+++ b/src/neuron/iz.jl
@@ -1,17 +1,17 @@
-@snn_kw struct IZParameter
-    a::Float32 = 0.01
-    b::Float32 = 0.2
-    c::Float32 = -65
-    d::Float32 = 2
+@snn_kw struct IZParameter{FT=Float32}
+    a::FT = 0.01
+    b::FT = 0.2
+    c::FT = -65
+    d::FT = 2
 end
 
-@snn_kw mutable struct IZ
+@snn_kw mutable struct IZ{FT=Vector{Float32},BT=Vector{Bool}}
     param::IZParameter = IZParameter()
     N::Int32 = 100
-    v::Vector{Float32} = fill(-65.0, N)
-    u::Vector{Float32} = param.b * v
-    fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{Float32} = zeros(N)
+    v::FT = fill(-65.0, N)
+    u::FT = param.b * v
+    fire::BT = zeros(Bool, N)
+    I::FT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/iz.jl
+++ b/src/neuron/iz.jl
@@ -1,21 +1,21 @@
-@with_kw struct IZParameter
-    a::SNNFloat = 0.01
-    b::SNNFloat = 0.2
-    c::SNNFloat = -65
-    d::SNNFloat = 2
+@snn_kw struct IZParameter
+    a::Float32 = 0.01
+    b::Float32 = 0.2
+    c::Float32 = -65
+    d::Float32 = 2
 end
 
-@with_kw mutable struct IZ
+@snn_kw mutable struct IZ
     param::IZParameter = IZParameter()
-    N::SNNInt = 100
-    v::Vector{SNNFloat} = fill(-65.0, N)
-    u::Vector{SNNFloat} = param.b * v
+    N::Int32 = 100
+    v::Vector{Float32} = fill(-65.0, N)
+    u::Vector{Float32} = param.b * v
     fire::Vector{Bool} = zeros(Bool, N)
-    I::Vector{SNNFloat} = zeros(N)
+    I::Vector{Float32} = zeros(N)
     records::Dict = Dict()
 end
 
-function integrate!(p::IZ, param::IZParameter, dt::SNNFloat)
+function integrate!(p::IZ, param::IZParameter, dt::Float32)
     @unpack N, v, u, fire, I = p
     @unpack a, b, c, d = param
     @inbounds for i = 1:N

--- a/src/neuron/iz.jl
+++ b/src/neuron/iz.jl
@@ -5,13 +5,13 @@
     d::FT = 2
 end
 
-@snn_kw mutable struct IZ{FT=Vector{Float32},BT=Vector{Bool}}
+@snn_kw mutable struct IZ{VFT=Vector{Float32},VBT=Vector{Bool}}
     param::IZParameter = IZParameter()
     N::Int32 = 100
-    v::FT = fill(-65.0, N)
-    u::FT = param.b * v
-    fire::BT = zeros(Bool, N)
-    I::FT = zeros(N)
+    v::VFT = fill(-65.0, N)
+    u::VFT = param.b * v
+    fire::VBT = zeros(Bool, N)
+    I::VFT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/noisy_if.jl
+++ b/src/neuron/noisy_if.jl
@@ -1,13 +1,13 @@
-@with_kw struct NoisyIFParameter <: AbstractIFParameter
-    σ::SNNFloat = 0
+@snn_kw struct NoisyIFParameter <: AbstractIFParameter
+    σ::Float32 = 0
 end
 
-@with_kw mutable struct NoisyIF <: AbstractIF
+@snn_kw mutable struct NoisyIF <: AbstractIF
     param::NoisyIFParameter = NoisyIFParameter()
-    randncache::Vector{SNNFloat} = randn(N)
+    randncache::Vector{Float32} = randn(N)
 end
 
-function integrate!(p::NoisyIF, param::NoisyIFParameter, dt::SNNFloat)
+function integrate!(p::NoisyIF, param::NoisyIFParameter, dt::Float32)
     randn!(randncache)
     @inbounds for i = 1:N
         v[i] += dt * (ge[i] + gi[i] - (v[i] - El) + I[i] + σ / √dt * randncache[i]) / τm

--- a/src/neuron/noisy_if.jl
+++ b/src/neuron/noisy_if.jl
@@ -1,10 +1,10 @@
-@snn_kw struct NoisyIFParameter <: AbstractIFParameter
-    σ::Float32 = 0
+@snn_kw struct NoisyIFParameter{FT=Float32} <: AbstractIFParameter
+    σ::FT = 0
 end
 
-@snn_kw mutable struct NoisyIF <: AbstractIF
+@snn_kw mutable struct NoisyIF{FT=Vector{Float32}} <: AbstractIF
     param::NoisyIFParameter = NoisyIFParameter()
-    randncache::Vector{Float32} = randn(N)
+    randncache::FT = randn(N)
 end
 
 function integrate!(p::NoisyIF, param::NoisyIFParameter, dt::Float32)

--- a/src/neuron/noisy_if.jl
+++ b/src/neuron/noisy_if.jl
@@ -2,9 +2,10 @@
     σ::FT = 0
 end
 
-@snn_kw mutable struct NoisyIF{FT=Vector{Float32}} <: AbstractIF
+@snn_kw mutable struct NoisyIF{VFT=Vector{Float32}} <: AbstractIF
     param::NoisyIFParameter = NoisyIFParameter()
-    randncache::FT = randn(N)
+    N::Int32 = 100
+    randncache::VFT = randn(N)
 end
 
 function integrate!(p::NoisyIF, param::NoisyIFParameter, dt::Float32)

--- a/src/neuron/poisson.jl
+++ b/src/neuron/poisson.jl
@@ -1,16 +1,16 @@
-@with_kw struct PoissonParameter
-    rate::SNNFloat = 1Hz
+@snn_kw struct PoissonParameter
+    rate::Float32 = 1Hz
 end
 
-@with_kw mutable struct Poisson
+@snn_kw mutable struct Poisson
     param::PoissonParameter = PoissonParameter()
-    N::SNNInt = 100
-    randcache::Vector{SNNFloat} = rand(N)
+    N::Int32 = 100
+    randcache::Vector{Float32} = rand(N)
     fire::Vector{Bool} = zeros(Bool, N)
     records::Dict = Dict()
 end
 
-function integrate!(p::Poisson, param::PoissonParameter, dt::SNNFloat)
+function integrate!(p::Poisson, param::PoissonParameter, dt::Float32)
     prob = rate * dt
     rand!(randcache)
     @inbounds for i = 1:N

--- a/src/neuron/poisson.jl
+++ b/src/neuron/poisson.jl
@@ -1,12 +1,12 @@
-@snn_kw struct PoissonParameter
-    rate::Float32 = 1Hz
+@snn_kw struct PoissonParameter{FT=Float32}
+    rate::FT = 1Hz
 end
 
-@snn_kw mutable struct Poisson
+@snn_kw mutable struct Poisson{FT=Vector{Float32},BT=Vector{Bool}}
     param::PoissonParameter = PoissonParameter()
     N::Int32 = 100
-    randcache::Vector{Float32} = rand(N)
-    fire::Vector{Bool} = zeros(Bool, N)
+    randcache::FT = rand(N)
+    fire::BT = zeros(Bool, N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/poisson.jl
+++ b/src/neuron/poisson.jl
@@ -2,11 +2,11 @@
     rate::FT = 1Hz
 end
 
-@snn_kw mutable struct Poisson{FT=Vector{Float32},BT=Vector{Bool}}
+@snn_kw mutable struct Poisson{VFT=Vector{Float32},VBT=Vector{Bool}}
     param::PoissonParameter = PoissonParameter()
     N::Int32 = 100
-    randcache::FT = rand(N)
-    fire::BT = zeros(Bool, N)
+    randcache::VFT = rand(N)
+    fire::VBT = zeros(Bool, N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/rate.jl
+++ b/src/neuron/rate.jl
@@ -1,13 +1,13 @@
 struct RateParameter
 end
 
-@snn_kw mutable struct Rate
+@snn_kw mutable struct Rate{FT=Vector{Float32}}
     param::RateParameter = RateParameter()
     N::Int32 = 100
-    x::Vector{Float32} = 0.5randn(N)
-    r::Vector{Float32} = tanh.(x)
-    g::Vector{Float32} = zeros(N)
-    I::Vector{Float32} = zeros(N)
+    x::FT = 0.5randn(N)
+    r::FT = tanh.(x)
+    g::FT = zeros(N)
+    I::FT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/neuron/rate.jl
+++ b/src/neuron/rate.jl
@@ -1,17 +1,17 @@
 struct RateParameter
 end
 
-@with_kw mutable struct Rate
+@snn_kw mutable struct Rate
     param::RateParameter = RateParameter()
-    N::SNNInt = 100
-    x::Vector{SNNFloat} = 0.5randn(N)
-    r::Vector{SNNFloat} = tanh.(x)
-    g::Vector{SNNFloat} = zeros(N)
-    I::Vector{SNNFloat} = zeros(N)
+    N::Int32 = 100
+    x::Vector{Float32} = 0.5randn(N)
+    r::Vector{Float32} = tanh.(x)
+    g::Vector{Float32} = zeros(N)
+    I::Vector{Float32} = zeros(N)
     records::Dict = Dict()
 end
 
-function integrate!(p::Rate, param::RateParameter, dt::SNNFloat)
+function integrate!(p::Rate, param::RateParameter, dt::Float32)
     @unpack N, x, r, g, I = p
     @inbounds for i = 1:N
         x[i] += dt * (-x[i] + g[i] + I[i])

--- a/src/neuron/rate.jl
+++ b/src/neuron/rate.jl
@@ -1,13 +1,13 @@
 struct RateParameter
 end
 
-@snn_kw mutable struct Rate{FT=Vector{Float32}}
+@snn_kw mutable struct Rate{VFT=Vector{Float32}}
     param::RateParameter = RateParameter()
     N::Int32 = 100
-    x::FT = 0.5randn(N)
-    r::FT = tanh.(x)
-    g::FT = zeros(N)
-    I::FT = zeros(N)
+    x::VFT = 0.5randn(N)
+    r::VFT = tanh.(x)
+    g::VFT = zeros(N)
+    I::VFT = zeros(N)
     records::Dict = Dict()
 end
 

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -3,7 +3,7 @@ using .Plots
 
 function raster(p)
     fire = p.records[:fire]
-    x, y = SNNFloat[], SNNFloat[]
+    x, y = Float32[], Float32[]
     for t = eachindex(fire)
         for n in findall(fire[t])
             push!(x, t)
@@ -14,8 +14,8 @@ function raster(p)
 end
 
 function raster(P::Array)
-    y0 = SNNInt[0]
-    X = SNNFloat[]; Y = SNNFloat[]
+    y0 = Int32[0]
+    X = Float32[]; Y = Float32[]
     for p in P
         x, y = raster(p)
         append!(X, x)
@@ -46,7 +46,7 @@ end
 
 function windowsize(p)
     A = sum.(p.records[:fire]) / length(p.N)
-    W = round(SNNInt, 0.5p.N / mean(A)) # filter window, unit=1
+    W = round(Int32, 0.5p.N / mean(A)) # filter window, unit=1
 end
 
 function density(p, sym)
@@ -94,7 +94,7 @@ end
 function if_curve(model, current; neuron = 1, dt = 0.1ms, duration = 1second)
     E = model(neuron)
     monitor(E, [:fire])
-    f = SNNFloat[]
+    f = Float32[]
     for I = current
         clear_records(E)
         E.I = [I]

--- a/src/synapse/fl_full_synapse.jl
+++ b/src/synapse/fl_full_synapse.jl
@@ -1,18 +1,18 @@
 struct FLSynapseParameter
 end
 
-@with_kw mutable struct FLSynapse
+@snn_kw mutable struct FLSynapse
     param::FLSynapseParameter = FLSynapseParameter()
-    W::Matrix{SNNFloat}  # synaptic weight
-    rI::Vector{SNNFloat} # postsynaptic rate
-    rJ::Vector{SNNFloat} # presynaptic rate
-    g::Vector{SNNFloat}  # postsynaptic conductance
-    P::Matrix{SNNFloat}  # <rᵢrⱼ>⁻¹
-    q::Vector{SNNFloat}  # P * r
-    u::Vector{SNNFloat} # force weight
-    w::Vector{SNNFloat} # output weight
-    f::SNNFloat = 0 # postsynaptic traget
-    z::SNNFloat = 0.5randn()  # output z ≈ f
+    W::Matrix{Float32}  # synaptic weight
+    rI::Vector{Float32} # postsynaptic rate
+    rJ::Vector{Float32} # presynaptic rate
+    g::Vector{Float32}  # postsynaptic conductance
+    P::Matrix{Float32}  # <rᵢrⱼ>⁻¹
+    q::Vector{Float32}  # P * r
+    u::Vector{Float32} # force weight
+    w::Vector{Float32} # output weight
+    f::Float32 = 0 # postsynaptic traget
+    z::Float32 = 0.5randn()  # output z ≈ f
     records::Dict = Dict()
 end
 
@@ -33,7 +33,7 @@ function forward!(c::FLSynapse, param::FLSynapseParameter)
     BLAS.axpy!(z, u, g)
 end
 
-function plasticity!(c::FLSynapse, param::FLSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::FLSynapse, param::FLSynapseParameter, dt::Float32, t::Float32)
     C = 1 / (1 + dot(q, rI))
     BLAS.axpy!(C * (f - z), q, w)
     BLAS.ger!(-C, q, q, P)

--- a/src/synapse/fl_full_synapse.jl
+++ b/src/synapse/fl_full_synapse.jl
@@ -1,18 +1,18 @@
 struct FLSynapseParameter
 end
 
-@snn_kw mutable struct FLSynapse
+@snn_kw mutable struct FLSynapse{MFT=Matrix{Float32},VFT=Vector{Float32},FT=Float32}
     param::FLSynapseParameter = FLSynapseParameter()
-    W::Matrix{Float32}  # synaptic weight
-    rI::Vector{Float32} # postsynaptic rate
-    rJ::Vector{Float32} # presynaptic rate
-    g::Vector{Float32}  # postsynaptic conductance
-    P::Matrix{Float32}  # <rᵢrⱼ>⁻¹
-    q::Vector{Float32}  # P * r
-    u::Vector{Float32} # force weight
-    w::Vector{Float32} # output weight
-    f::Float32 = 0 # postsynaptic traget
-    z::Float32 = 0.5randn()  # output z ≈ f
+    W::MFT  # synaptic weight
+    rI::VFT # postsynaptic rate
+    rJ::VFT # presynaptic rate
+    g::VFT  # postsynaptic conductance
+    P::MFT  # <rᵢrⱼ>⁻¹
+    q::VFT  # P * r
+    u::VFT # force weight
+    w::VFT # output weight
+    f::FT = 0 # postsynaptic traget
+    z::FT = 0.5randn()  # output z ≈ f
     records::Dict = Dict()
 end
 

--- a/src/synapse/fl_full_synapse.jl
+++ b/src/synapse/fl_full_synapse.jl
@@ -16,14 +16,14 @@ end
     records::Dict = Dict()
 end
 
-function FLSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
+function FLSynapse(pre, post; σ = 1.5, p = 0.0, α = 1, kwargs...)
     rI, rJ, g = post.r, pre.r, post.g
     W = σ * 1 / √pre.N * randn(post.N, pre.N) # normalized recurrent weight
-    w = 1 / √post.N * (2rand(post.N) - 1) # initial output weight
-    u = 2rand(post.N) - 1 # initial force weight
-    P = α * eye(post.N) # initial inverse of C = <rr'>
+    w = 1 / √post.N * (2rand(post.N) .- 1) # initial output weight
+    u = 2rand(post.N) .- 1 # initial force weight
+    P = α * I(post.N) # initial inverse of C = <rr'>
     q = zeros(post.N)
-    FLSynapse(;@symdict(W, rI, rJ, g, P, q, u, w)...)
+    FLSynapse(;@symdict(W, rI, rJ, g, P, q, u, w)..., kwargs...)
 end
 
 function forward!(c::FLSynapse, param::FLSynapseParameter)

--- a/src/synapse/fl_synapse.jl
+++ b/src/synapse/fl_synapse.jl
@@ -18,7 +18,7 @@ end
     records::Dict = Dict()
 end
 
-function FLSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
+function FLSynapse(pre, post; σ = 1.5, p = 0.0, α = 1, kwargs...)
     w = σ * 1 / √(p * pre.N) * sprandn(post.N, pre.N, p)
     rowptr, colptr, I, J, index, W = dsparse(w)
     rI, rJ, g = post.r, pre.r, post.g
@@ -26,7 +26,7 @@ function FLSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
     q = zeros(post.N)
     u = 2rand(post.N) - 1
     w = 1 / √post.N * (2rand(post.N) - 1)
-    FLSynapse(;@symdict(colptr, I, W, rI, rJ, g, P, q, u, w)...)
+    FLSynapse(;@symdict(colptr, I, W, rI, rJ, g, P, q, u, w)..., kwargs...)
 end
 
 function forward!(c::FLSynapse, param::FLSynapseParameter)

--- a/src/synapse/fl_synapse.jl
+++ b/src/synapse/fl_synapse.jl
@@ -1,20 +1,20 @@
 struct FLSynapseParameter
 end
 
-@snn_kw mutable struct FLSynapse
+@snn_kw mutable struct FLSynapse{VFT=Vector{Float32},FT=Float32}
     param::FLSynapseParameter = FLSynapseParameter()
     colptr::Vector{Int32} # column pointer of sparse W
     I::Vector{Int32}      # postsynaptic index of W
-    W::Vector{Float32}  # synaptic weight
-    rI::Vector{Float32} # postsynaptic rate
-    rJ::Vector{Float32} # presynaptic rate
-    g::Vector{Float32}  # postsynaptic conductance
-    P::Vector{Float32}  # <rᵢrⱼ>⁻¹
-    q::Vector{Float32}  # P * r
-    u::Vector{Float32} # force weight
-    w::Vector{Float32} # output weight
-    f::Float32 = 0 # postsynaptic traget
-    z::Float32 = 0.5randn()  # output z ≈ f
+    W::VFT  # synaptic weight
+    rI::VFT # postsynaptic rate
+    rJ::VFT # presynaptic rate
+    g::VFT  # postsynaptic conductance
+    P::VFT  # <rᵢrⱼ>⁻¹
+    q::VFT  # P * r
+    u::VFT # force weight
+    w::VFT # output weight
+    f::FT = 0 # postsynaptic traget
+    z::FT = 0.5randn()  # output z ≈ f
     records::Dict = Dict()
 end
 

--- a/src/synapse/fl_synapse.jl
+++ b/src/synapse/fl_synapse.jl
@@ -1,20 +1,20 @@
 struct FLSynapseParameter
 end
 
-@with_kw mutable struct FLSynapse
+@snn_kw mutable struct FLSynapse
     param::FLSynapseParameter = FLSynapseParameter()
-    colptr::Vector{SNNInt} # column pointer of sparse W
-    I::Vector{SNNInt}      # postsynaptic index of W
-    W::Vector{SNNFloat}  # synaptic weight
-    rI::Vector{SNNFloat} # postsynaptic rate
-    rJ::Vector{SNNFloat} # presynaptic rate
-    g::Vector{SNNFloat}  # postsynaptic conductance
-    P::Vector{SNNFloat}  # <rᵢrⱼ>⁻¹
-    q::Vector{SNNFloat}  # P * r
-    u::Vector{SNNFloat} # force weight
-    w::Vector{SNNFloat} # output weight
-    f::SNNFloat = 0 # postsynaptic traget
-    z::SNNFloat = 0.5randn()  # output z ≈ f
+    colptr::Vector{Int32} # column pointer of sparse W
+    I::Vector{Int32}      # postsynaptic index of W
+    W::Vector{Float32}  # synaptic weight
+    rI::Vector{Float32} # postsynaptic rate
+    rJ::Vector{Float32} # presynaptic rate
+    g::Vector{Float32}  # postsynaptic conductance
+    P::Vector{Float32}  # <rᵢrⱼ>⁻¹
+    q::Vector{Float32}  # P * r
+    u::Vector{Float32} # force weight
+    w::Vector{Float32} # output weight
+    f::Float32 = 0 # postsynaptic traget
+    z::Float32 = 0.5randn()  # output z ≈ f
     records::Dict = Dict()
 end
 
@@ -32,7 +32,7 @@ end
 function forward!(c::FLSynapse, param::FLSynapseParameter)
     z = dot(w, rI)
     g .= z .* u
-    fill!(q, zero(SNNFloat))
+    fill!(q, zero(Float32))
     @inbounds for j in 1:(length(colptr) - 1)
         rJj = rJ[j]
         for s = colptr[j]:(colptr[j+1] - 1)
@@ -43,7 +43,7 @@ function forward!(c::FLSynapse, param::FLSynapseParameter)
     end
 end
 
-function plasticity!(c::FLSynapse, param::FLSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::FLSynapse, param::FLSynapseParameter, dt::Float32, t::Float32)
     C = 1 / (1 + dot(q, rI))
     BLAS.axpy!(C * (f - z), q, w)
     @inbounds for j in 1:(length(colptr) - 1)

--- a/src/synapse/pinning_full_synapse.jl
+++ b/src/synapse/pinning_full_synapse.jl
@@ -13,12 +13,12 @@ end
     records::Dict = Dict()
 end
 
-function PINningSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
+function PINningSynapse(pre, post; σ = 1.5, p = 0.0, α = 1, kwargs...)
     rI, rJ, g = post.r, pre.r, post.g
     W = σ * 1 / √pre.N * randn(post.N, pre.N) # normalized recurrent weight
-    P = α * eye(post.N) # initial inverse of C = <rr'>
+    P = α * I(post.N) # initial inverse of C = <rr'>
     f, q = zeros(post.N), zeros(post.N)
-    PINningSynapse(;@symdict(W, rI, rJ, g, P, q, f)...)
+    PINningSynapse(;@symdict(W, rI, rJ, g, P, q, f)..., kwargs...)
 end
 
 function forward!(c::PINningSynapse, param::PINningSynapseParameter)

--- a/src/synapse/pinning_full_synapse.jl
+++ b/src/synapse/pinning_full_synapse.jl
@@ -1,15 +1,15 @@
 struct PINningSynapseParameter
 end
 
-@snn_kw mutable struct PINningSynapse
+@snn_kw mutable struct PINningSynapse{MFT=Matrix{Float32},VFT=Vector{Float32}}
     param::PINningSynapseParameter = PINningSynapseParameter()
-    W::Matrix{Float32}  # synaptic weight
-    rI::Vector{Float32} # postsynaptic rate
-    rJ::Vector{Float32} # presynaptic rate
-    g::Vector{Float32}  # postsynaptic conductance
-    P::Matrix{Float32}  # <rᵢrⱼ>⁻¹
-    q::Vector{Float32}  # P * r
-    f::Vector{Float32}  # postsynaptic traget
+    W::MFT  # synaptic weight
+    rI::VFT # postsynaptic rate
+    rJ::VFT # presynaptic rate
+    g::VFT  # postsynaptic conductance
+    P::MFT  # <rᵢrⱼ>⁻¹
+    q::VFT  # P * r
+    f::VFT  # postsynaptic traget
     records::Dict = Dict()
 end
 

--- a/src/synapse/pinning_full_synapse.jl
+++ b/src/synapse/pinning_full_synapse.jl
@@ -1,15 +1,15 @@
 struct PINningSynapseParameter
 end
 
-@with_kw mutable struct PINningSynapse
+@snn_kw mutable struct PINningSynapse
     param::PINningSynapseParameter = PINningSynapseParameter()
-    W::Matrix{SNNFloat}  # synaptic weight
-    rI::Vector{SNNFloat} # postsynaptic rate
-    rJ::Vector{SNNFloat} # presynaptic rate
-    g::Vector{SNNFloat}  # postsynaptic conductance
-    P::Matrix{SNNFloat}  # <rᵢrⱼ>⁻¹
-    q::Vector{SNNFloat}  # P * r
-    f::Vector{SNNFloat}  # postsynaptic traget
+    W::Matrix{Float32}  # synaptic weight
+    rI::Vector{Float32} # postsynaptic rate
+    rJ::Vector{Float32} # presynaptic rate
+    g::Vector{Float32}  # postsynaptic conductance
+    P::Matrix{Float32}  # <rᵢrⱼ>⁻¹
+    q::Vector{Float32}  # P * r
+    f::Vector{Float32}  # postsynaptic traget
     records::Dict = Dict()
 end
 
@@ -26,7 +26,7 @@ function forward!(c::PINningSynapse, param::PINningSynapseParameter)
     BLAS.A_mul_B!(g, W, rJ)
 end
 
-function plasticity!(c::PINningSynapse, param::PINningSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::PINningSynapse, param::PINningSynapseParameter, dt::Float32, t::Float32)
     C = 1 / (1 + dot(q, rI))
     BLAS.ger!(C, f - g, q, W)
     BLAS.ger!(-C, q, q, P)

--- a/src/synapse/pinning_synapse.jl
+++ b/src/synapse/pinning_synapse.jl
@@ -1,17 +1,17 @@
 struct PINningSynapseParameter
 end
 
-@with_kw mutable struct PINningSynapse
+@snn_kw mutable struct PINningSynapse
     param::PINningSynapseParameter = PINningSynapseParameter()
-    colptr::Vector{SNNInt} # column pointer of sparse W
-    I::Vector{SNNInt}      # postsynaptic index of W
-    W::Vector{SNNFloat}  # synaptic weight
-    rI::Vector{SNNFloat} # postsynaptic rate
-    rJ::Vector{SNNFloat} # presynaptic rate
-    g::Vector{SNNFloat}  # postsynaptic conductance
-    P::Vector{SNNFloat}  # <rᵢrⱼ>⁻¹
-    q::Vector{SNNFloat}  # P * r
-    f::Vector{SNNFloat}  # postsynaptic traget
+    colptr::Vector{Int32} # column pointer of sparse W
+    I::Vector{Int32}      # postsynaptic index of W
+    W::Vector{Float32}  # synaptic weight
+    rI::Vector{Float32} # postsynaptic rate
+    rJ::Vector{Float32} # presynaptic rate
+    g::Vector{Float32}  # postsynaptic conductance
+    P::Vector{Float32}  # <rᵢrⱼ>⁻¹
+    q::Vector{Float32}  # P * r
+    f::Vector{Float32}  # postsynaptic traget
     records::Dict = Dict()
 end
 
@@ -25,8 +25,8 @@ function PINningSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
 end
 
 function forward!(c::PINningSynapse, param::PINningSynapseParameter)
-    fill!(q, zero(SNNFloat))
-    fill!(g, zero(SNNFloat))
+    fill!(q, zero(Float32))
+    fill!(g, zero(Float32))
     @inbounds for j in 1:(length(colptr) - 1)
         rJj = rJ[j]
         for s = colptr[j]:(colptr[j+1] - 1)
@@ -37,7 +37,7 @@ function forward!(c::PINningSynapse, param::PINningSynapseParameter)
     end
 end
 
-function plasticity!(c::PINningSynapse, param::PINningSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::PINningSynapse, param::PINningSynapseParameter, dt::Float32, t::Float32)
     C = 1 / (1 + dot(q, rI))
     @inbounds for j in 1:(length(colptr) - 1)
         for s in colptr[j]:(colptr[j+1] - 1)

--- a/src/synapse/pinning_synapse.jl
+++ b/src/synapse/pinning_synapse.jl
@@ -15,13 +15,13 @@ end
     records::Dict = Dict()
 end
 
-function PINningSynapse(pre, post; σ = 1.5, p = 0.0, α = 1)
+function PINningSynapse(pre, post; σ = 1.5, p = 0.0, α = 1, kwargs...)
     w = σ / √(p * pre.N) * sprandn(post.N, pre.N, p)
     rowptr, colptr, I, J, index, W = dsparse(w)
     rI, rJ, g = post.r, pre.r, post.g
     P = α .* (I .== J)
     f, q = zeros(post.N), zeros(post.N)
-    PINningSynapse(;@symdict(colptr, I, W, rI, rJ, g, P, q, f)...)
+    PINningSynapse(;@symdict(colptr, I, W, rI, rJ, g, P, q, f)..., kwargs...)
 end
 
 function forward!(c::PINningSynapse, param::PINningSynapseParameter)

--- a/src/synapse/pinning_synapse.jl
+++ b/src/synapse/pinning_synapse.jl
@@ -1,17 +1,17 @@
 struct PINningSynapseParameter
 end
 
-@snn_kw mutable struct PINningSynapse
+@snn_kw mutable struct PINningSynapse{VIT=Vector{Int32},VFT=Vector{Float32}}
     param::PINningSynapseParameter = PINningSynapseParameter()
-    colptr::Vector{Int32} # column pointer of sparse W
-    I::Vector{Int32}      # postsynaptic index of W
-    W::Vector{Float32}  # synaptic weight
-    rI::Vector{Float32} # postsynaptic rate
-    rJ::Vector{Float32} # presynaptic rate
-    g::Vector{Float32}  # postsynaptic conductance
-    P::Vector{Float32}  # <rᵢrⱼ>⁻¹
-    q::Vector{Float32}  # P * r
-    f::Vector{Float32}  # postsynaptic traget
+    colptr::VIT # column pointer of sparse W
+    I::VIT      # postsynaptic index of W
+    W::VFT  # synaptic weight
+    rI::VFT # postsynaptic rate
+    rJ::VFT # presynaptic rate
+    g::VFT  # postsynaptic conductance
+    P::VFT  # <rᵢrⱼ>⁻¹
+    q::VFT  # P * r
+    f::VFT  # postsynaptic traget
     records::Dict = Dict()
 end
 

--- a/src/synapse/rate_synapse.jl
+++ b/src/synapse/rate_synapse.jl
@@ -13,11 +13,11 @@ end
     records::Dict = Dict()
 end
 
-function RateSynapse(pre, post; σ = 0.0, p = 0.0)
+function RateSynapse(pre, post; σ = 0.0, p = 0.0, kwargs...)
     w = σ / √(p * pre.N) * sprandn(post.N, pre.N, p)
     rowptr, colptr, I, J, index, W = dsparse(w)
     rI, rJ, g = post.r, pre.r, post.g
-    RateSynapse(;@symdict(colptr, I, W, rI, rJ, g)...)
+    RateSynapse(;@symdict(colptr, I, W, rI, rJ, g)..., kwargs...)
 end
 
 function forward!(c::RateSynapse, param::RateSynapseParameter)

--- a/src/synapse/rate_synapse.jl
+++ b/src/synapse/rate_synapse.jl
@@ -1,15 +1,15 @@
-@snn_kw struct RateSynapseParameter
-    lr::Float32 = 1e-3
+@snn_kw struct RateSynapseParameter{FT=Float32}
+    lr::FT = 1e-3
 end
 
-@snn_kw mutable struct RateSynapse
+@snn_kw mutable struct RateSynapse{VIT=Vector{Int32},VFT=Vector{Float32}}
     param::RateSynapseParameter = RateSynapseParameter()
-    colptr::Vector{Int32} # column pointer of sparse W
-    I::Vector{Int32}      # postsynaptic index of W
-    W::Vector{Float32}  # synaptic weight
-    rI::Vector{Float32} # postsynaptic rate
-    rJ::Vector{Float32} # presynaptic rate
-    g::Vector{Float32}  # postsynaptic conductance
+    colptr::VIT # column pointer of sparse W
+    I::VIT      # postsynaptic index of W
+    W::VFT  # synaptic weight
+    rI::VFT # postsynaptic rate
+    rJ::VFT # presynaptic rate
+    g::VFT  # postsynaptic conductance
     records::Dict = Dict()
 end
 

--- a/src/synapse/rate_synapse.jl
+++ b/src/synapse/rate_synapse.jl
@@ -1,15 +1,15 @@
-@with_kw struct RateSynapseParameter
-    lr::SNNFloat = 1e-3
+@snn_kw struct RateSynapseParameter
+    lr::Float32 = 1e-3
 end
 
-@with_kw mutable struct RateSynapse
+@snn_kw mutable struct RateSynapse
     param::RateSynapseParameter = RateSynapseParameter()
-    colptr::Vector{SNNInt} # column pointer of sparse W
-    I::Vector{SNNInt}      # postsynaptic index of W
-    W::Vector{SNNFloat}  # synaptic weight
-    rI::Vector{SNNFloat} # postsynaptic rate
-    rJ::Vector{SNNFloat} # presynaptic rate
-    g::Vector{SNNFloat}  # postsynaptic conductance
+    colptr::Vector{Int32} # column pointer of sparse W
+    I::Vector{Int32}      # postsynaptic index of W
+    W::Vector{Float32}  # synaptic weight
+    rI::Vector{Float32} # postsynaptic rate
+    rJ::Vector{Float32} # presynaptic rate
+    g::Vector{Float32}  # postsynaptic conductance
     records::Dict = Dict()
 end
 
@@ -32,12 +32,12 @@ function forward!(c::RateSynapse, param::RateSynapseParameter)
     end
 end
 
-function plasticity!(c::RateSynapse, param::RateSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::RateSynapse, param::RateSynapseParameter, dt::Float32, t::Float32)
     @unpack colptr, I, W, rI, rJ, g = c
     @unpack lr = param
     @inbounds for j in 1:(length(colptr) - 1)
         s_row = colptr[j]:(colptr[j+1] - 1)
-        rIW = zero(SNNFloat)
+        rIW = zero(Float32)
         for s in s_row
             rIW += rI[I[s]] * W[s]
         end

--- a/src/synapse/spiking_synapse.jl
+++ b/src/synapse/spiking_synapse.jl
@@ -1,26 +1,26 @@
-@with_kw struct SpikingSynapseParameter
-    τpre::SNNFloat = 20ms
-    τpost::SNNFloat = 20ms
-    Wmax::SNNFloat = 0.01
-    ΔApre::SNNFloat = 0.01 * Wmax
-    ΔApost::SNNFloat = -ΔApre * τpre / τpost * 1.05
+@snn_kw struct SpikingSynapseParameter
+    τpre::Float32 = 20ms
+    τpost::Float32 = 20ms
+    Wmax::Float32 = 0.01
+    ΔApre::Float32 = 0.01 * Wmax
+    ΔApost::Float32 = -ΔApre * τpre / τpost * 1.05
 end
 
-@with_kw mutable struct SpikingSynapse
+@snn_kw mutable struct SpikingSynapse
     param::SpikingSynapseParameter = SpikingSynapseParameter()
-    rowptr::Vector{SNNInt} # row pointer of sparse W
-    colptr::Vector{SNNInt} # column pointer of sparse W
-    I::Vector{SNNInt}      # postsynaptic index of W
-    J::Vector{SNNInt}      # presynaptic index of W
-    index::Vector{SNNInt}  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
-    W::Vector{SNNFloat}  # synaptic weight
-    tpre::Vector{SNNFloat} = zero(W) # presynaptic spiking time
-    tpost::Vector{SNNFloat} = zero(W) # postsynaptic spiking time
-    Apre::Vector{SNNFloat} = zero(W) # presynaptic trace
-    Apost::Vector{SNNFloat} = zero(W) # postsynaptic trace
+    rowptr::Vector{Int32} # row pointer of sparse W
+    colptr::Vector{Int32} # column pointer of sparse W
+    I::Vector{Int32}      # postsynaptic index of W
+    J::Vector{Int32}      # presynaptic index of W
+    index::Vector{Int32}  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
+    W::Vector{Float32}  # synaptic weight
+    tpre::Vector{Float32} = zero(W) # presynaptic spiking time
+    tpost::Vector{Float32} = zero(W) # postsynaptic spiking time
+    Apre::Vector{Float32} = zero(W) # presynaptic trace
+    Apost::Vector{Float32} = zero(W) # postsynaptic trace
     fireI::Vector{Bool} # postsynaptic firing
     fireJ::Vector{Bool} # presynaptic firing
-    g::Vector{SNNFloat} # postsynaptic conductance
+    g::Vector{Float32} # postsynaptic conductance
     records::Dict = Dict()
 end
 
@@ -43,7 +43,7 @@ function forward!(c::SpikingSynapse, param::SpikingSynapseParameter)
     end
 end
 
-function plasticity!(c::SpikingSynapse, param::SpikingSynapseParameter, dt::SNNFloat, t::SNNFloat)
+function plasticity!(c::SpikingSynapse, param::SpikingSynapseParameter, dt::Float32, t::Float32)
     @unpack rowptr, colptr, I, J, index, W, tpre, tpost, Apre, Apost, fireI, fireJ, g = c
     @unpack τpre, τpost, Wmax, ΔApre, ΔApost = param
     @inbounds for j in 1:(length(colptr) - 1)

--- a/src/synapse/spiking_synapse.jl
+++ b/src/synapse/spiking_synapse.jl
@@ -24,12 +24,12 @@ end
     records::Dict = Dict()
 end
 
-function SpikingSynapse(pre, post, sym; σ = 0.0, p = 0.0)
+function SpikingSynapse(pre, post, sym; σ = 0.0, p = 0.0, kwargs...)
     w = σ * sprand(post.N, pre.N, p)
     rowptr, colptr, I, J, index, W = dsparse(w)
     fireI, fireJ = post.fire, pre.fire
     g = getfield(post, sym)
-    SpikingSynapse(;@symdict(rowptr, colptr, I, J, index, W, fireI, fireJ, g)...)
+    SpikingSynapse(;@symdict(rowptr, colptr, I, J, index, W, fireI, fireJ, g)..., kwargs...)
 end
 
 function forward!(c::SpikingSynapse, param::SpikingSynapseParameter)

--- a/src/synapse/spiking_synapse.jl
+++ b/src/synapse/spiking_synapse.jl
@@ -1,26 +1,26 @@
-@snn_kw struct SpikingSynapseParameter
-    τpre::Float32 = 20ms
-    τpost::Float32 = 20ms
-    Wmax::Float32 = 0.01
-    ΔApre::Float32 = 0.01 * Wmax
-    ΔApost::Float32 = -ΔApre * τpre / τpost * 1.05
+@snn_kw struct SpikingSynapseParameter{FT=Float32}
+    τpre::FT = 20ms
+    τpost::FT = 20ms
+    Wmax::FT = 0.01
+    ΔApre::FT = 0.01 * Wmax
+    ΔApost::FT = -ΔApre * τpre / τpost * 1.05
 end
 
-@snn_kw mutable struct SpikingSynapse
+@snn_kw mutable struct SpikingSynapse{VIT=Vector{Int32},VFT=Vector{Float32},VBT=Vector{Bool}}
     param::SpikingSynapseParameter = SpikingSynapseParameter()
-    rowptr::Vector{Int32} # row pointer of sparse W
-    colptr::Vector{Int32} # column pointer of sparse W
-    I::Vector{Int32}      # postsynaptic index of W
-    J::Vector{Int32}      # presynaptic index of W
-    index::Vector{Int32}  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
-    W::Vector{Float32}  # synaptic weight
-    tpre::Vector{Float32} = zero(W) # presynaptic spiking time
-    tpost::Vector{Float32} = zero(W) # postsynaptic spiking time
-    Apre::Vector{Float32} = zero(W) # presynaptic trace
-    Apost::Vector{Float32} = zero(W) # postsynaptic trace
-    fireI::Vector{Bool} # postsynaptic firing
-    fireJ::Vector{Bool} # presynaptic firing
-    g::Vector{Float32} # postsynaptic conductance
+    rowptr::VIT # row pointer of sparse W
+    colptr::VIT # column pointer of sparse W
+    I::VIT      # postsynaptic index of W
+    J::VIT      # presynaptic index of W
+    index::VIT  # index mapping: W[index[i]] = Wt[i], Wt = sparse(dense(W)')
+    W::VFT  # synaptic weight
+    tpre::VFT = zero(W) # presynaptic spiking time
+    tpost::VFT = zero(W) # postsynaptic spiking time
+    Apre::VFT = zero(W) # presynaptic trace
+    Apost::VFT = zero(W) # postsynaptic trace
+    fireI::VBT # postsynaptic firing
+    fireJ::VBT # presynaptic firing
+    g::VFT # postsynaptic conductance
     records::Dict = Dict()
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 function connect!(c, j, i, σ = 1e-6)
     W = sparse(c.I, c.J, c.W, length(c.rowptr) - 1, length(c.colptr) - 1)
-    W[i, j] = σ * randn(SNNFloat)
+    W[i, j] = σ * randn(Float32)
     c.rowptr, c.colptr, c.I, c.J, c.index, c.W = dsparse(W)
     c.tpre, c.tpost, c.Apre, c.Apost = zero(c.W), zero(c.W), zero(c.W), zero(c.W)
     return nothing
@@ -73,14 +73,14 @@ function clear_records(obj)
     end
 end
 
-@inline function exp32(x::SNNFloat)
+@inline function exp32(x::Float32)
     x = ifelse(x < -10f0, -32f0, x)
     x = 1f0 + x / 32f0
     x *= x; x *= x; x *= x; x *= x; x *= x
     return x
 end
 
-@inline function exp256(x::SNNFloat)
+@inline function exp256(x::Float32)
     x = ifelse(x < -10f0, -256f0, x)
     x = 1.0f0 + x / 256.0f0
     x *= x; x *= x; x *= x; x *= x
@@ -96,4 +96,131 @@ macro symdict(x...)
     end
     push!(ex.args, :(d))
     return ex
+end
+
+snn_kw_str_param(x::Symbol) = (x,)
+function snn_kw_str_param(x::Expr)
+    if x.head == :(<:)
+        return (x.args...,)
+    elseif x.head == :(=) && x.args[1].head == :(<:)
+        return (x.args[1].args..., x.args[2])
+    else
+        error("Can't handle param Expr: $x")
+    end
+end
+snn_kw_str_field(x::Symbol) = (x,)
+function snn_kw_str_field(x::Expr)
+    if x.head == :(::)
+        return (x.args...,)
+    elseif x.head == :(=)
+        return (x.args[1].args[1:2]..., x.args[2])
+    else
+        error("Can't handle field Expr: $x")
+    end
+end
+function snn_kw_str_kws(x::Tuple)
+    if 1 <= length(x) <= 2
+        return x[1]
+    elseif length(x) == 3
+        return Expr(:kw, x[1], x[3])
+    end
+end
+function snn_kw_str_kws_types(x::Tuple)
+    if 1 <= length(x) <= 2
+        return Expr(:(::), x[1], x[2])
+    elseif length(x) == 3
+        return Expr(:kw, x[1], x[3])
+    end
+end
+struct KwStrSentinel end
+function snn_kw_str_sentinels(x)
+    if length(x) == 1
+        return (x[1], Any, :(KwStrSentinel()))
+    elseif length(x) == 2
+        return (x[1], Any, :(KwStrSentinel()))
+    else
+        return x
+    end
+end
+snn_kw_str_sentinel_check(x) =
+    :(if $(x[1]) isa KwStrSentinel
+        $(x[1]) = $(length(x) > 1 ? x[2] : Any)
+    end)
+"A minimal implementation of `Base.@kwdef` with default type parameter support"
+macro snn_kw(str)
+    str_abs = nothing
+    if str.args[2] isa Expr && str.args[2].head == :(<:)
+        # Lower abstract type
+        str_abs = str.args[2].args[2]
+        str.args[2] = str.args[2].args[1]
+    end
+    if str.args[2] isa Symbol
+        # No type params
+        str_name = str.args[2]
+        str_params = []
+    else
+        # Has type params
+        str_name = str.args[2].args[1]
+        str_params = map(snn_kw_str_param, str.args[2].args[2:end])
+    end
+    @assert str_name isa Symbol
+    str_fields = map(snn_kw_str_field, filter(x->!(x isa LineNumberNode),
+                                          str.args[3].args))
+
+    # Replace abstract type
+    if str_abs !== nothing
+        str.args[2] = Expr(:(<:), str.args[2], str_abs)
+    end
+
+    # Remove default type params
+    if length(str_params) > 0
+        idx = 1
+        for idx in 2:length(str.args[2].args)
+            param = str_params[idx-1]
+            if length(param) == 1
+                str.args[2].args[idx] = param[1]
+            else
+                str.args[2].args[idx] = Expr(:(<:), param[1:2]...)
+            end
+        end
+    end
+
+    # Remove default field values
+    idx = 1
+    subidx = 1
+    for idx in 1:length(str.args[3].args)
+        if !(str.args[3].args[idx] isa LineNumberNode)
+            field = str_fields[subidx]
+            if length(field) == 1
+                str.args[3].args[idx] = field[1]
+            else
+                str.args[3].args[idx] = Expr(:(::), field[1:2]...)
+            end
+            subidx += 1
+        end
+    end
+
+    # Use sentinels to track if type param kwargs are assigned
+    ctor_params = snn_kw_str_sentinels.(str_params)
+    ctor_params_bodies = snn_kw_str_sentinel_check.(str_params)
+
+    # Accept field values and type params as kwargs
+    ctor_kws = Expr(:parameters,
+                    map(snn_kw_str_kws, str_fields)...,
+                    map(snn_kw_str_kws_types, ctor_params)...)
+    ctor_sig = Expr(:call, str_name, ctor_kws)
+    ctor_call = if length(str_params) > 0
+        Expr(:curly, str_name, first.(str_params)...)
+    else
+        str_name
+    end
+    ctor_body = Expr(:block,
+                     ctor_params_bodies...,
+                     Expr(:call, ctor_call, first.(str_fields)...))
+    ctor = Expr(:function, ctor_sig, ctor_body)
+
+    return quote
+        $(esc(str))
+        $(esc(ctor))
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,7 +207,7 @@ macro snn_kw(str)
     ctor_params = snn_kw_str_sentinels.(str_params)
     ctor_params_bodies = snn_kw_str_sentinel_check.(str_params)
 
-    # Accept field values and type params as kwargs
+    # Constructor accepts field values and type params as kwargs
     ctor_kws = Expr(:parameters,
                     map(snn_kw_str_kws, str_fields)...,
                     map(snn_kw_str_kws_types, ctor_params)...)
@@ -222,8 +222,6 @@ macro snn_kw(str)
                      Expr(:call, ctor_call, first.(str_fields)...))
     ctor = Expr(:function, ctor_sig, ctor_body)
 
-    @show str_name
-    @show str
     return quote
         $(esc(str))
         $(esc(ctor))

--- a/test/ctors.jl
+++ b/test/ctors.jl
@@ -3,11 +3,9 @@
 coretype(T::UnionAll) = coretype(T.body)
 coretype(T::DataType) = T
 paramnames(T) = coretype(T).parameters
-
-@testset  "Neuron ctors" begin
-for _Model in (SNN.HH, SNN.IF, SNN.IF2, SNN.IZ, SNN.NoisyIF, SNN.Poisson, SNN.Rate)
-    Model = coretype(_Model)
-    n = Model()
+function test_typeparams(Model; args=())
+    Model = coretype(Model)
+    n = Model(args...)
     for idx in 1:length(fieldnames(Model))
         fieldtypes(Model)[idx] isa TypeVar || continue
         field, Tf = fieldnames(Model)[idx], fieldtypes(Model)[idx].name
@@ -15,22 +13,33 @@ for _Model in (SNN.HH, SNN.IF, SNN.IF2, SNN.IZ, SNN.NoisyIF, SNN.Poisson, SNN.Ra
         # TODO: Test where vector is not <: DenseArray
         if Tf == :FT
             @test getfield(n, field) isa Float32
-            _n = Model(;FT=Float64)
+            _n = Model(args...;FT=Float64)
             @test getfield(_n, field) isa Float64
         elseif Tf == :VFT
             @test getfield(n, field) isa Vector{Float32}
-            _n = Model(;VFT=Vector{Float64})
+            _n = Model(args...;VFT=Vector{Float64})
             @test getfield(_n, field) isa Vector{Float64}
         elseif Tf == :MFT
             @test getfield(n, field) isa Matrix{Float32}
-            _n = Model(;MFT=Matrix{Float64})
+            _n = Model(args...;MFT=Matrix{Float64})
             @test getfield(_n, field) isa Matrix{Float64}
         elseif Tf == :VBT
             @test getfield(n, field) isa Vector{Bool}
-            _n = Model(;VBT=Vector{Any})
+            _n = Model(args...;VBT=Vector{Any})
             @test getfield(_n, field) isa Vector{Any}
             @test getfield(_n, field)[1] isa Bool
         end
     end
 end
-end
+
+@testset "Constructors" begin
+@testset "Type parameters" begin
+    for Model in (SNN.HH, SNN.IF, SNN.IF2, SNN.IZ, SNN.NoisyIF, SNN.Poisson, SNN.Rate)
+        test_typeparams(Model)
+    end
+    test_typeparams(SNN.RateSynapse; args=(SNN.Rate(),SNN.Rate()))
+    test_typeparams(SNN.PINningSynapse; args=(SNN.Rate(),SNN.Rate()))
+    test_typeparams(SNN.FLSynapse; args=(SNN.Rate(),SNN.Rate()))
+    test_typeparams(SNN.SpikingSynapse; args=(SNN.IF(),SNN.IF(),:ge))
+end # Type parameters
+end # Constructors

--- a/test/ctors.jl
+++ b/test/ctors.jl
@@ -1,0 +1,36 @@
+# Tests for @snn_kw constructors
+
+coretype(T::UnionAll) = coretype(T.body)
+coretype(T::DataType) = T
+paramnames(T) = coretype(T).parameters
+
+@testset  "Neuron ctors" begin
+for _Model in (SNN.HH, SNN.IF, SNN.IF2, SNN.IZ, SNN.NoisyIF, SNN.Poisson, SNN.Rate)
+    Model = coretype(_Model)
+    n = Model()
+    for idx in 1:length(fieldnames(Model))
+        fieldtypes(Model)[idx] isa TypeVar || continue
+        field, Tf = fieldnames(Model)[idx], fieldtypes(Model)[idx].name
+
+        # TODO: Test where vector is not <: DenseArray
+        if Tf == :FT
+            @test getfield(n, field) isa Float32
+            _n = Model(;FT=Float64)
+            @test getfield(_n, field) isa Float64
+        elseif Tf == :VFT
+            @test getfield(n, field) isa Vector{Float32}
+            _n = Model(;VFT=Vector{Float64})
+            @test getfield(_n, field) isa Vector{Float64}
+        elseif Tf == :MFT
+            @test getfield(n, field) isa Matrix{Float32}
+            _n = Model(;MFT=Matrix{Float64})
+            @test getfield(_n, field) isa Matrix{Float64}
+        elseif Tf == :VBT
+            @test getfield(n, field) isa Vector{Bool}
+            _n = Model(;VBT=Vector{Any})
+            @test getfield(_n, field) isa Vector{Any}
+            @test getfield(_n, field)[1] isa Bool
+        end
+    end
+end
+end

--- a/test/ctors.jl
+++ b/test/ctors.jl
@@ -3,6 +3,9 @@
 coretype(T::UnionAll) = coretype(T.body)
 coretype(T::DataType) = T
 paramnames(T) = coretype(T).parameters
+if VERSION < v"1.1.0-DEV.441"
+    fieldtypes(T) = ntuple(i -> fieldtype(T, i), fieldcount(T))
+end
 function test_typeparams(Model; args=())
     Model = coretype(Model)
     n = Model(args...)

--- a/test/ctors.jl
+++ b/test/ctors.jl
@@ -3,9 +3,6 @@
 coretype(T::UnionAll) = coretype(T.body)
 coretype(T::DataType) = T
 paramnames(T) = coretype(T).parameters
-if VERSION < v"1.1.0-DEV.441"
-    fieldtypes(T) = ntuple(i -> fieldtype(T, i), fieldcount(T))
-end
 function test_typeparams(Model; args=())
     Model = coretype(Model)
     n = Model(args...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,9 @@ using SpikingNeuralNetworks
 include(joinpath(@__DIR__, "..", "src", "units.jl")) # FIXME
 using Test
 
+if VERSION < v"1.1"
 include("ctors.jl")
+end
 include("chain.jl")
 include("hh_net.jl")
 include("hh_neuron.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,11 @@
 #using Plots; plotly()
 using SpikingNeuralNetworks
-const SNN = SpikingNeuralNetworks
 #using Unitful
 #using Unitful.DefaultSymbols
 include(joinpath(@__DIR__, "..", "src", "units.jl")) # FIXME
+using Test
 
+include("ctors.jl")
 include("chain.jl")
 include("hh_net.jl")
 include("hh_neuron.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using SpikingNeuralNetworks
 include(joinpath(@__DIR__, "..", "src", "units.jl")) # FIXME
 using Test
 
-if VERSION < v"1.1"
+if VERSION > v"1.1"
 include("ctors.jl")
 end
 include("chain.jl")


### PR DESCRIPTION
Intended to support #16 and make those changes mostly non-breaking. A big change here is the removal of `Parameters` as a dependency, and the introduction of an `@snn_kw` macro which does less, but importantly supports default type parameters. This macro can eventually be upstreamed to either Parameters.jl or Julia Base (as `Base.@kwdef`).

Todo:
- [x] Parameterize neuron/synapse structs such that we can replace `Vector`s with other array types (like GPU arrays or Tracked arrays)
- [ ] ~Adjust internal integration/training methods to use ModelingToolkit/OrdinaryDiffEq~
- [x] Add tests for newly-parameterized neurons/synapses